### PR TITLE
Lots of little changes.

### DIFF
--- a/.termux/litmux_colors.sh
+++ b/.termux/litmux_colors.sh
@@ -19,6 +19,7 @@ while true; do
     echo "Please enter the right number!";
   elif (( $number>=0 && $number<=$count )); then
     eval choice=${colors_name[number]};
+    echo "Copying $COLORS_DIR/$choice to $HOME/.termux/colors.properties"
     cp -fr "$COLORS_DIR/$choice" "$HOME/.termux/colors.properties";
     break;
   else

--- a/.termux/litmux_colors.sh
+++ b/.termux/litmux_colors.sh
@@ -1,6 +1,5 @@
 #!/data/data/com.termux/files/usr/bin/bash
-DIR=`cd $(dirname $0); pwd`
-COLORS_DIR=$DIR/colors
+COLORS_DIR="$HOME/.oh-my-zsh/custom/misc/LitMux/.termux/colors"
 count=0
 
 echo -e "The default color theme is Tango.\nYou can choose another one from the list below";
@@ -20,7 +19,7 @@ while true; do
     echo "Please enter the right number!";
   elif (( $number>=0 && $number<=$count )); then
     eval choice=${colors_name[number]};
-    cp -fr "$COLORS_DIR/$choice" "$DIR/colors.properties";
+    cp -fr "$COLORS_DIR/$choice" "$HOME/.termux/colors.properties";
     break;
   else
     echo "Please enter the right number!";

--- a/install.sh
+++ b/install.sh
@@ -70,8 +70,9 @@ sed -i 's~\(ZSH_THEME="\)[^"]*\(".*\)~\1powerlevel10k/powerlevel10k\2~' ~/.zshrc
 # Installing the Powerline font for Termux.
 curl -fsSL -o ~/.termux/font.ttf 'https://github.com/romkatv/dotfiles-public/raw/master/.local/share/fonts/NerdFonts/MesloLGS%20NF%20Regular.ttf'
 
-# TODO: set 'Tango' as the default color scheme for the shell.
-#cp -fr "$HOME/.oh-my-zsh/custom/misc/LitMux/.termux/colors.properties" ~/colors.properties
+# Set 'Tango' as the default color scheme for the shell.
+cp -fr "$HOME/.oh-my-zsh/custom/misc/LitMux/.termux/colors.properties" ~/.termux/colors.properties
+termux-reload-settings
 
 # Run a ZSH shell, opens the p10k config wizard if not set up already.
 exec zsh -l

--- a/install.sh
+++ b/install.sh
@@ -14,12 +14,14 @@ git_force_clone_shallow () {
    if [ -d "$2" ]; then
    rm -rf "$2"
    fi
-   git clone --depth 1 $1 $2
+   git clone --depth 1 "$1" "$2"
 }
 
 sed_handle_plugin_zshrc () {
-   if [ ! grep "^plugins=*$1*" ~/.zshrc ]; then
-   sed -i 's/\(^plugins=([^)]*\)/\1 $1/' ~/.zshrc
+   if  grep "^plugins=*$1*" ~/.zshrc ; then
+   true
+   else
+   sed -i "s/\(^plugins=([^)]*\)/\1 $1/" ~/.zshrc
    fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -49,8 +49,8 @@ chsh -s zsh
 
 # Adding aliases for stuff
 sed_handle_alias_zshrc "litmux-color" "'$HOME/.oh-my-zsh/custom/misc/LitMux/.termux/litmux_colors.sh'"
-sed_handle_alias_zshrc "litmux-style" "p10k configure'"
-sed_handle_alias_zshrc "litmux-update" "upgrade_oh_my_zsh"
+sed_handle_alias_zshrc "litmux-style" "'p10k configure'"
+sed_handle_alias_zshrc "litmux-update" "'upgrade_oh_my_zsh'"
 
 # Installing "Syntax Highlighting" addon for ZSH, and appending that to the plugins list.
 git_force_clone_shallow https://github.com/zsh-users/zsh-syntax-highlighting.git "$HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting"

--- a/install.sh
+++ b/install.sh
@@ -26,21 +26,17 @@ git clone https://github.com/AvinashReddy3108/LitMux.git "$HOME/.LitMux" --depth
 
 # Making a backup of Termux config directory,
 # just in case you want to revert.
-mv "$HOME/.termux" "$HOME/.termux.bak.$(date +%Y.%m.%d-%H:%M:%S)"
+mv -f "$HOME/.termux" "$HOME/.termux.bak"
 cp -R "$HOME/.LitMux/.termux" "$HOME/.termux"
 
-# Installing Oh My ZSH as a replacement of BASH,
-# plus setting up .zshrc file, and adding aliases.
+# Installing Oh My ZSH as a replacement of BASH.
+echo "Installing oh-my-ZSH..."
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh) --unattended" > /dev/null
 
-if [ -d "$HOME/.oh-my-zsh" ]; then
-rm -rf "$HOME/.oh-my-zsh"
-fi
+# Changing default shell to ZSH, goodbye boring BASH.
+chsh -s zsh
 
-git clone git://github.com/robbyrussell/oh-my-zsh.git "$HOME/.oh-my-zsh" --depth 1
-mv "$HOME/.zshrc" "$HOME/.zshrc.bak.$(date +%Y.%m.%d-%H:%M:%S)"
-cp "$HOME/.oh-my-zsh/templates/zshrc.zsh-template" "$HOME/.zshrc"
-sed -i '/^ZSH_THEME/d' "$HOME/.zshrc"
-sed -i '1iZSH_THEME="agnoster"' "$HOME/.zshrc"
+# Adding aliases for stuff
 echo "alias chcolor='$HOME/.termux/litmux_colors.sh'" >> "$HOME/.zshrc"
 
 # Installing Syntax Highlighting addon for ZSH,
@@ -62,13 +58,10 @@ fi
 
 git clone https://github.com/romkatv/powerlevel10k.git "$HOME/.powerlevel10k" --depth 1
 echo "source $HOME/.powerlevel10k/powerlevel10k.zsh-theme" >> "$HOME/.zshrc"
+sed -i 's~\(ZSH_THEME="\)[^"]*\(".*\)~\1powerlevel10k/powerlevel10k\2~' "$HOME/.zshrc"
 
 # Installing the Powerline font for Termux.
 curl -fsSL -o ~/.termux/font.ttf 'https://github.com/romkatv/dotfiles-public/raw/master/.local/share/fonts/NerdFonts/MesloLGS%20NF%20Regular.ttf'
-
-# Changing default shell to ZSH,
-# goodbye boring BASH.
-chsh -s zsh
 
 # Choosing a cool color scheme for ZSH.
 clear

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,12 @@ git_force_clone_shallow () {
    git clone --depth 1 $1 $2
 }
 
+sed_handle_plugin_zshrc () {
+   if [ ! grep "^plugins=*$1*" ~/.zshrc ]
+   sed -i 's/\(^plugins=([^)]*\)/\1 $1/' ~/.zshrc
+   fi
+}
+
 # Giving Storage permision to Termux App.
 termux-setup-storage
 
@@ -38,17 +44,17 @@ echo "alias litmux-update='upgrade_oh_my_zsh'"
 
 # Installing "Syntax Highlighting" addon for ZSH, and appending that to the plugins list.
 git_force_clone_shallow https://github.com/zsh-users/zsh-syntax-highlighting.git "$HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting"
-sed -i 's/\(^plugins=([^)]*\)/\1 zsh-syntax-highlighting/' ~/.zshrc
+sed_handle_plugin_zshrc zsh-syntax-highlighting
 
 # Installing "Custom Plugins Updater" addon for ZSH, and appending that to the plugins list.
 git_force_clone_shallow https://github.com/TamCore/autoupdate-oh-my-zsh-plugins "$HOME/.oh-my-zsh/custom/plugins/autoupdate"
-sed -i 's/\(^plugins=([^)]*\)/\1 autoupdate/' ~/.zshrc
+sed_handle_plugin_zshrc autoupdate
 
 # Cloning the LITMUX repo, to be handled by the Oh-My-ZSH updater.
 git_force_clone_shallow https://github.com/AvinashReddy3108/LitMux.git "$HOME/.oh-my-zsh/custom/misc/LitMux"
 
 # Installing powerlevel10k theme for ZSH, and making it the current theme in .zshrc file.
-git_force_clone_shallow https://github.com/romkatv/powerlevel10k.git "$HOME/.oh-my-zsh/custom/themes/zsh-syntax-highlighting"
+git_force_clone_shallow https://github.com/romkatv/powerlevel10k.git "$HOME/.oh-my-zsh/custom/themes/powerlevel10k"
 sed -i 's~\(ZSH_THEME="\)[^"]*\(".*\)~\1powerlevel10k/powerlevel10k\2~' ~/.zshrc
 
 # Installing the Powerline font for Termux.

--- a/install.sh
+++ b/install.sh
@@ -18,61 +18,38 @@ termux-setup-storage
 pkg update
 pkg install -y git zsh
 
-if [ -d "$HOME/.LitMux" ]; then
-rm -rf "$HOME/.LitMux"
-fi
-
-git clone https://github.com/AvinashReddy3108/LitMux.git "$HOME/.LitMux" --depth 1
-
-# Making a backup of Termux config directory,
-# just in case you want to revert.
-mv -f "$HOME/.termux" "$HOME/.termux.bak"
-cp -R "$HOME/.LitMux/.termux" "$HOME/.termux"
-
 # Installing Oh My ZSH as a replacement of BASH.
 echo "Installing oh-my-ZSH..."
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh) --unattended" > /dev/null
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh) --unattended"
 
 # Changing default shell to ZSH, goodbye boring BASH.
 chsh -s zsh
 
 # Adding aliases for stuff
-echo "alias chcolor='$HOME/.termux/litmux_colors.sh'" >> "$HOME/.zshrc"
+echo "alias litmux-color='$HOME/.oh-my-zsh/custom/misc/LitMux/litmux_colors.sh'" >> ~/.zshrc
+echo "alias litmux-style='p10k configure'"
+echo "alias litmux-update='upgrade_oh_my_zsh'"
 
-# Installing Syntax Highlighting addon for ZSH,
-# and sourcing it in the .zshrc file.
+# Installing "Syntax Highlighting" addon for ZSH, and appending that to the plugins list.
+git clone --depth 1 https://github.com/zsh-users/zsh-syntax-highlighting.git "$HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting"
+sed -i 's/\(^plugins=([^)]*\)/\1 zsh-syntax-highlighting/' ~/.zshrc
 
-if [ -d "$HOME/.zsh-syntax-highlighting" ]; then
-rm -rf "$HOME/.zsh-syntax-highlighting"
-fi
+# Installing "Custom Plugins Updater" addon for ZSH, and appending that to the plugins list.
+git clone --depth 1 https://github.com/TamCore/autoupdate-oh-my-zsh-plugins "$HOME/.oh-my-zsh/custom/plugins/autoupdate"
+sed -i 's/\(^plugins=([^)]*\)/\1 autoupdate/' ~/.zshrc
 
-git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$HOME/.zsh-syntax-highlighting" --depth 1
-echo "source $HOME/.zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" >> "$HOME/.zshrc"
+# Cloning the LITMUX repo, to be handled by the Oh-My-ZSH updater.
+git clone --depth 1 https://github.com/AvinashReddy3108/LitMux.git "$HOME/.oh-my-zsh/custom/misc/LitMux"
 
-# Installing powerlevel10k theme for ZSH,
-# and sourcing it in the .zshrc file.
-
-if [ -d "$HOME/.powerlevel10k" ]; then
-rm -rf "$HOME/.powerlevel10k"
-fi
-
-git clone https://github.com/romkatv/powerlevel10k.git "$HOME/.powerlevel10k" --depth 1
-echo "source $HOME/.powerlevel10k/powerlevel10k.zsh-theme" >> "$HOME/.zshrc"
-sed -i 's~\(ZSH_THEME="\)[^"]*\(".*\)~\1powerlevel10k/powerlevel10k\2~' "$HOME/.zshrc"
+# Installing powerlevel10k theme for ZSH, and making it the current theme in .zshrc file.
+git clone --depth 1 https://github.com/romkatv/powerlevel10k.git "$HOME/.oh-my-zsh/custom/themes/zsh-syntax-highlighting"
+sed -i 's~\(ZSH_THEME="\)[^"]*\(".*\)~\1powerlevel10k/powerlevel10k\2~' ~/.zshrc
 
 # Installing the Powerline font for Termux.
 curl -fsSL -o ~/.termux/font.ttf 'https://github.com/romkatv/dotfiles-public/raw/master/.local/share/fonts/NerdFonts/MesloLGS%20NF%20Regular.ttf'
 
-# Choosing a cool color scheme for ZSH.
-clear
-echo "Let's choose a good color scheme for the shell, shall we ?"
-echo "NOTE: use 'chcolor' to change shell colors anytime later."
-echo ""
-$HOME/.termux/litmux_colors.sh
+# set 'Tango' as the default color scheme for the shell.
+cp -fr "$HOME/.oh-my-zsh/custom/misc/LitMux/.termux/colors.properties" ~/colors.properties
 
-clear
-termux-reload-settings
-echo "LitMux Installed successfully, gimme cookies !"
-echo "Restart the Termux app to enjoy the LIT experience."
-echo "NOTE: use 'p10k configure' to configure your terminal prompt anytime later."
-exit
+# Run
+exec -l zsh

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,14 @@ sed_handle_plugin_zshrc () {
    fi
 }
 
+sed_handle_alias_zshrc () {
+   if  grep "^alias $1=*" ~/.zshrc ; then
+   true
+   else
+   echo "alias $1=$2" >> ~/.zshrc
+   fi
+}
+
 # Giving Storage permision to Termux App.
 termux-setup-storage
 
@@ -40,17 +48,17 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/mas
 chsh -s zsh
 
 # Adding aliases for stuff
-echo "alias litmux-color='$HOME/.oh-my-zsh/custom/misc/LitMux/litmux_colors.sh'" >> ~/.zshrc
-echo "alias litmux-style='p10k configure'"
-echo "alias litmux-update='upgrade_oh_my_zsh'"
+sed_handle_alias_zshrc "litmux-color" "'$HOME/.oh-my-zsh/custom/misc/LitMux/.termux/litmux_colors.sh'"
+sed_handle_alias_zshrc "litmux-style" "p10k configure'"
+sed_handle_alias_zshrc "litmux-update" "upgrade_oh_my_zsh"
 
 # Installing "Syntax Highlighting" addon for ZSH, and appending that to the plugins list.
 git_force_clone_shallow https://github.com/zsh-users/zsh-syntax-highlighting.git "$HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting"
-sed_handle_plugin_zshrc zsh-syntax-highlighting
+sed_handle_plugin_zshrc "zsh-syntax-highlighting"
 
 # Installing "Custom Plugins Updater" addon for ZSH, and appending that to the plugins list.
 git_force_clone_shallow https://github.com/TamCore/autoupdate-oh-my-zsh-plugins "$HOME/.oh-my-zsh/custom/plugins/autoupdate"
-sed_handle_plugin_zshrc autoupdate
+sed_handle_plugin_zshrc "autoupdate"
 
 # Cloning the LITMUX repo, to be handled by the Oh-My-ZSH updater.
 git_force_clone_shallow https://github.com/AvinashReddy3108/LitMux.git "$HOME/.oh-my-zsh/custom/misc/LitMux"
@@ -62,8 +70,8 @@ sed -i 's~\(ZSH_THEME="\)[^"]*\(".*\)~\1powerlevel10k/powerlevel10k\2~' ~/.zshrc
 # Installing the Powerline font for Termux.
 curl -fsSL -o ~/.termux/font.ttf 'https://github.com/romkatv/dotfiles-public/raw/master/.local/share/fonts/NerdFonts/MesloLGS%20NF%20Regular.ttf'
 
-# set 'Tango' as the default color scheme for the shell.
-cp -fr "$HOME/.oh-my-zsh/custom/misc/LitMux/.termux/colors.properties" ~/colors.properties
+# TODO: set 'Tango' as the default color scheme for the shell.
+#cp -fr "$HOME/.oh-my-zsh/custom/misc/LitMux/.termux/colors.properties" ~/colors.properties
 
-# Run a ZSH shell, atleast for the powerlevel10k wizard
+# Run a ZSH shell, opens the p10k config wizard if not set up already.
 exec zsh -l

--- a/install.sh
+++ b/install.sh
@@ -51,5 +51,5 @@ curl -fsSL -o ~/.termux/font.ttf 'https://github.com/romkatv/dotfiles-public/raw
 # set 'Tango' as the default color scheme for the shell.
 cp -fr "$HOME/.oh-my-zsh/custom/misc/LitMux/.termux/colors.properties" ~/colors.properties
 
-# Run
-exec -l zsh
+# Run a ZSH shell, atleast for the powerlevel10k wizard
+exec zsh -l

--- a/install.sh
+++ b/install.sh
@@ -10,11 +10,17 @@ echo "";
 echo "      Ditch the boring BASH and get LIT !!      ";
 sleep 3
 
+git_force_clone_shallow () {
+   if [ -d "$2" ]; then
+   rm -rf "$2"
+   fi
+   git clone --depth 1 $1 $2
+}
+
 # Giving Storage permision to Termux App.
 termux-setup-storage
 
-# Updating package repositories 
-# and installing requirements.
+# Updating package repositories and installing requirements.
 pkg update
 pkg install -y git zsh
 
@@ -31,18 +37,18 @@ echo "alias litmux-style='p10k configure'"
 echo "alias litmux-update='upgrade_oh_my_zsh'"
 
 # Installing "Syntax Highlighting" addon for ZSH, and appending that to the plugins list.
-git clone --depth 1 https://github.com/zsh-users/zsh-syntax-highlighting.git "$HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting"
+git_force_clone_shallow https://github.com/zsh-users/zsh-syntax-highlighting.git "$HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting"
 sed -i 's/\(^plugins=([^)]*\)/\1 zsh-syntax-highlighting/' ~/.zshrc
 
 # Installing "Custom Plugins Updater" addon for ZSH, and appending that to the plugins list.
-git clone --depth 1 https://github.com/TamCore/autoupdate-oh-my-zsh-plugins "$HOME/.oh-my-zsh/custom/plugins/autoupdate"
+git_force_clone_shallow https://github.com/TamCore/autoupdate-oh-my-zsh-plugins "$HOME/.oh-my-zsh/custom/plugins/autoupdate"
 sed -i 's/\(^plugins=([^)]*\)/\1 autoupdate/' ~/.zshrc
 
 # Cloning the LITMUX repo, to be handled by the Oh-My-ZSH updater.
-git clone --depth 1 https://github.com/AvinashReddy3108/LitMux.git "$HOME/.oh-my-zsh/custom/misc/LitMux"
+git_force_clone_shallow https://github.com/AvinashReddy3108/LitMux.git "$HOME/.oh-my-zsh/custom/misc/LitMux"
 
 # Installing powerlevel10k theme for ZSH, and making it the current theme in .zshrc file.
-git clone --depth 1 https://github.com/romkatv/powerlevel10k.git "$HOME/.oh-my-zsh/custom/themes/zsh-syntax-highlighting"
+git_force_clone_shallow https://github.com/romkatv/powerlevel10k.git "$HOME/.oh-my-zsh/custom/themes/zsh-syntax-highlighting"
 sed -i 's~\(ZSH_THEME="\)[^"]*\(".*\)~\1powerlevel10k/powerlevel10k\2~' ~/.zshrc
 
 # Installing the Powerline font for Termux.

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ git_force_clone_shallow () {
 }
 
 sed_handle_plugin_zshrc () {
-   if [ ! grep "^plugins=*$1*" ~/.zshrc ]
+   if [ ! grep "^plugins=*$1*" ~/.zshrc ]; then
    sed -i 's/\(^plugins=([^)]*\)/\1 $1/' ~/.zshrc
    fi
 }


### PR DESCRIPTION
- Uses the official Oh-My-ZSH install script.
- The powerlevel10k theme is applied as the `ZSH_THEME` variable instead of sourcing it separately.
- The plugins should now be installed in the `$ZSH_CUSTOM` directory along with placing their entries in the `plugins=(...)` placeholder in the `.zshrc` file.
- Added some aliases for easy configuration/updates later.
- A restart of the Termux app is not needed to setup the powerlevel10k theme (for those who installed this script on a clean install of Termux.)